### PR TITLE
feat: Allow external aiohttp.ClientSession injection

### DIFF
--- a/renogyapi/__init__.py
+++ b/renogyapi/__init__.py
@@ -124,7 +124,7 @@ class Renogy:
             message = {"error": ERROR_TIMEOUT}
         except ContentTypeError as err:
             _LOGGER.error("%s", err)
-            message = {"error": err}
+            message = {"error": f"{err.__class__.__name__}: {err}"}
 
         return message
 

--- a/renogyapi/__init__.py
+++ b/renogyapi/__init__.py
@@ -110,7 +110,7 @@ class Renogy:
                     raise RateLimit
                 if response.status != 200:
                     _LOGGER.error(  # pylint: disable-next=line-too-long
-                        "An error reteiving data from the server, code: %s\nmessage: %s",  # noqa: E501
+                        "An error retrieving data from the server, code: %s\nmessage: %s",
                         response.status,
                         message,
                     )

--- a/renogyapi/__init__.py
+++ b/renogyapi/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
@@ -118,8 +119,7 @@ class Renogy:
                     if not isinstance(message, dict) or "error" not in message:
                         message = {"error": message}
                 return message
-
-        except (TimeoutError, ServerTimeoutError):
+        except (TimeoutError, asyncio.TimeoutError, ServerTimeoutError):
             _LOGGER.error("%s: %s", ERROR_TIMEOUT, url)
             message = {"error": ERROR_TIMEOUT}
         except ContentTypeError as err:

--- a/renogyapi/__init__.py
+++ b/renogyapi/__init__.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import time
 import json
 import logging
+import time
 from typing import Any
 from urllib.parse import urlencode
 
@@ -110,7 +110,8 @@ class Renogy:
                     raise RateLimit
                 if response.status != 200:
                     _LOGGER.error(  # pylint: disable-next=line-too-long
-                        "An error retrieving data from the server, code: %s\nmessage: %s",
+                        "An error retrieving data from the server, code: %s\n"
+                        "message: %s",
                         response.status,
                         message,
                     )

--- a/renogyapi/__init__.py
+++ b/renogyapi/__init__.py
@@ -1,4 +1,4 @@
-"""Main librbary functions for py_renogy."""
+"""Main library functions for py_renogy."""
 
 from __future__ import annotations
 
@@ -197,7 +197,7 @@ class Renogy:
         return self._device_list
 
     async def get_realtime_data(self, device_id: str) -> dict:
-        """Provide reatime data of specified device_id."""
+        """Provide realtime data of specified device_id."""
         timestamp = int(time.time() * 1000)
         path = f"/device/data/latest/{device_id}"
         params: dict[Any, Any] = {}

--- a/renogyapi/__init__.py
+++ b/renogyapi/__init__.py
@@ -57,10 +57,12 @@ class Renogy:
         self,
         secret_key: str,
         access_key: str,
+        session: aiohttp.ClientSession | None = None,
     ) -> None:
         """Initialize."""
         self._key = secret_key
         self._access_key = access_key
+        self._session = session
         self._device_list: dict[Any, Any] = {}
 
     async def process_request(
@@ -69,49 +71,61 @@ class Renogy:
         headers: dict,
     ) -> dict[Any, Any]:
         """Process API requests."""
-        async with aiohttp.ClientSession(headers=headers) as session:
-            _LOGGER.debug("Request URL: %s", url)
-            timeout = aiohttp.ClientTimeout(total=90)
-            try:
-                async with session.get(url, timeout=timeout) as response:
-                    message: Any = {}
-                    try:
-                        message = await response.text()
-                    except UnicodeDecodeError:
-                        _LOGGER.debug("Decoding error.")
-                        data = await response.read()
-                        message = data.decode(errors="replace")
+        if self._session is not None:
+            return await self._request(self._session, url, headers)
 
-                    try:
-                        message = json.loads(message)
-                    except ValueError:
-                        _LOGGER.warning("Non-JSON response: %s", message)
+        async with aiohttp.ClientSession() as session:
+            return await self._request(session, url, headers)
+
+    async def _request(
+        self,
+        session: aiohttp.ClientSession,
+        url: str,
+        headers: dict,
+    ) -> dict[Any, Any]:
+        """Process API requests."""
+        _LOGGER.debug("Request URL: %s", url)
+        timeout = aiohttp.ClientTimeout(total=90)
+        try:
+            async with session.get(url, headers=headers, timeout=timeout) as response:
+                message: Any = {}
+                try:
+                    message = await response.text()
+                except UnicodeDecodeError:
+                    _LOGGER.debug("Decoding error.")
+                    data = await response.read()
+                    message = data.decode(errors="replace")
+
+                try:
+                    message = json.loads(message)
+                except ValueError:
+                    _LOGGER.warning("Non-JSON response: %s", message)
+                    message = {"error": message}
+
+                if response.status == 404:
+                    raise UrlNotFound
+                if response.status == 401:
+                    raise NotAuthorized
+                if response.status == 429:
+                    raise RateLimit
+                if response.status != 200:
+                    _LOGGER.error(  # pylint: disable-next=line-too-long
+                        "An error reteiving data from the server, code: %s\nmessage: %s",  # noqa: E501
+                        response.status,
+                        message,
+                    )
+                    if not isinstance(message, dict) or "error" not in message:
                         message = {"error": message}
+                return message
 
-                    if response.status == 404:
-                        raise UrlNotFound
-                    if response.status == 401:
-                        raise NotAuthorized
-                    if response.status == 429:
-                        raise RateLimit
-                    if response.status != 200:
-                        _LOGGER.error(  # pylint: disable-next=line-too-long
-                            "An error reteiving data from the server, code: %s\nmessage: %s",  # noqa: E501
-                            response.status,
-                            message,
-                        )
-                        message = {"error": message}
-                    return message
+        except (TimeoutError, ServerTimeoutError):
+            _LOGGER.error("%s: %s", ERROR_TIMEOUT, url)
+            message = {"error": ERROR_TIMEOUT}
+        except ContentTypeError as err:
+            _LOGGER.error("%s", err)
+            message = {"error": err}
 
-            except (TimeoutError, ServerTimeoutError):
-                _LOGGER.error("%s: %s", ERROR_TIMEOUT, url)
-                message = {"error": ERROR_TIMEOUT}
-            except ContentTypeError as err:
-                _LOGGER.error("%s", err)
-                message = {"error": err}
-
-            await session.close()
-            return message
+        return message
 
     async def get_devices(self) -> dict:
         """Provide list of devices associated with account."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -270,3 +270,5 @@ async def test_process_request_content_type_error(mock_aioclient):
     )
     resp = await handler.process_request(BASE_URL + "/contenttype", {})
     assert "error" in resp
+    assert isinstance(resp["error"], str)
+    assert "ContentTypeError" in resp["error"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,11 +2,11 @@
 
 import json
 import logging
-
-import pytest
-import aiohttp
-from aiohttp.client_exceptions import ServerTimeoutError, ContentTypeError
 from unittest.mock import MagicMock
+
+import aiohttp
+import pytest
+from aiohttp.client_exceptions import ContentTypeError, ServerTimeoutError
 
 import renogyapi
 from renogyapi.exceptions import NoDevices, NotAuthorized, RateLimit, UrlNotFound

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,7 +4,9 @@ import json
 import logging
 
 import pytest
-from aiohttp.client_exceptions import ServerTimeoutError
+import aiohttp
+from aiohttp.client_exceptions import ServerTimeoutError, ContentTypeError
+from unittest.mock import MagicMock
 
 import renogyapi
 from renogyapi.exceptions import NoDevices, NotAuthorized, RateLimit, UrlNotFound
@@ -191,3 +193,80 @@ async def test_get_devices_no_sublist(mock_aioclient, caplog):
     with caplog.at_level(logging.DEBUG):
         await handler.get_devices()
     assert "No subdevices found." in caplog.text
+
+
+async def test_get_devices_with_session(mock_aioclient):
+    """Test get_devices function with external session."""
+    mock_aioclient.get(
+        BASE_URL + DEVICE_LIST,
+        status=200,
+        body="[]",
+    )
+    async with aiohttp.ClientSession() as session:
+        handler = renogyapi.Renogy(
+            secret_key="fakeSecretKey", access_key="FakeAccessKey", session=session
+        )
+        with pytest.raises(NoDevices):
+            await handler.get_devices()
+
+
+async def test_process_request_errors(mock_aioclient):
+    """Test process_request error statuses."""
+    handler = renogyapi.Renogy(secret_key="fakeSecretKey", access_key="FakeAccessKey")
+
+    mock_aioclient.get(BASE_URL + "/404", status=404)
+    with pytest.raises(UrlNotFound):
+        await handler.process_request(BASE_URL + "/404", {})
+
+    mock_aioclient.get(BASE_URL + "/401", status=401)
+    with pytest.raises(NotAuthorized):
+        await handler.process_request(BASE_URL + "/401", {})
+
+    mock_aioclient.get(BASE_URL + "/429", status=429)
+    with pytest.raises(RateLimit):
+        await handler.process_request(BASE_URL + "/429", {})
+
+    mock_aioclient.get(BASE_URL + "/500", status=500, body="Error")
+    resp = await handler.process_request(BASE_URL + "/500", {})
+    assert resp == {"error": "Error"}
+
+    mock_aioclient.get(BASE_URL + "/500json", status=500, body='{"msg": "failure"}')
+    resp = await handler.process_request(BASE_URL + "/500json", {})
+    assert resp == {"error": {"msg": "failure"}}
+
+
+async def test_process_request_exceptions(mock_aioclient):
+    """Test process_request exceptions."""
+    handler = renogyapi.Renogy(secret_key="fakeSecretKey", access_key="FakeAccessKey")
+
+    # Timeout
+    mock_aioclient.get(BASE_URL + "/timeout", exception=ServerTimeoutError())
+    resp = await handler.process_request(BASE_URL + "/timeout", {})
+    assert resp == {"error": renogyapi.ERROR_TIMEOUT}
+
+    # Non-JSON response
+    mock_aioclient.get(BASE_URL + "/nonjson", status=200, body="Not JSON")
+    resp = await handler.process_request(BASE_URL + "/nonjson", {})
+    assert resp == {"error": "Not JSON"}
+
+
+async def test_process_request_unicode_error(mock_aioclient):
+    """Test process_request UnicodeDecodeError handling."""
+    handler = renogyapi.Renogy(secret_key="fakeSecretKey", access_key="FakeAccessKey")
+
+    # body=b"\xff" triggers UnicodeDecodeError on text()
+    mock_aioclient.get(BASE_URL + "/unicode", status=200, body=b"\xff")
+    resp = await handler.process_request(BASE_URL + "/unicode", {})
+    assert "error" in resp
+    assert resp["error"] == "\ufffd"
+
+
+async def test_process_request_content_type_error(mock_aioclient):
+    """Test process_request ContentTypeError handling."""
+    handler = renogyapi.Renogy(secret_key="fakeSecretKey", access_key="FakeAccessKey")
+
+    mock_aioclient.get(
+        BASE_URL + "/contenttype", exception=ContentTypeError(MagicMock(), ())
+    )
+    resp = await handler.process_request(BASE_URL + "/contenttype", {})
+    assert "error" in resp


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional support for supplying an external HTTP session so the client can reuse connections.

* **Bug Fixes**
  * Unified HTTP request flow with improved, consistent error payloads for timeouts, decoding failures, non-JSON responses, and common HTTP status codes (401, 404, 429, 500).

* **Tests**
  * Expanded coverage for session reuse and many HTTP error, decoding, and exception scenarios.

* **Documentation**
  * Minor docstring typo corrected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->